### PR TITLE
Rejuvenate log levels (CWS/1000)

### DIFF
--- a/src/edu/stanford/nlp/ie/machinereading/ExtractorMerger.java
+++ b/src/edu/stanford/nlp/ie/machinereading/ExtractorMerger.java
@@ -36,7 +36,7 @@ public class ExtractorMerger implements Extractor {
   @Override
   public void annotate(Annotation dataset) {
     // TODO for now, we only merge RelationMentions
-    logger.info("Extractor 0 annotating dataset.");
+    logger.fine("Extractor 0 annotating dataset.");
     extractors[0].annotate(dataset);
 
     // store all the RelationMentions per sentence
@@ -49,7 +49,7 @@ public class ExtractorMerger implements Extractor {
 
     // skip first extractor since we did it at the top
     for (int extractorIndex = 1; extractorIndex < extractors.length; extractorIndex++) {
-      logger.info("Extractor " + extractorIndex + " annotating dataset.");
+      logger.fine("Extractor " + extractorIndex + " annotating dataset.");
       Extractor extractor = extractors[extractorIndex];
       extractor.annotate(dataset);
 
@@ -75,7 +75,7 @@ public class ExtractorMerger implements Extractor {
     BasicRelationExtractor[] relationExtractorComponents = new BasicRelationExtractor[extractorModelNames.length];
     for (int i = 0; i < extractorModelNames.length; i++) {
       String modelName = extractorModelNames[i];
-      logger.info("Loading model " + i + " for model merging from " + modelName);
+      logger.fine("Loading model " + i + " for model merging from " + modelName);
       try {
         relationExtractorComponents[i] = BasicRelationExtractor.load(modelName);
       } catch (IOException | ClassNotFoundException e) {


### PR DESCRIPTION
We appreciate your previous feedback and it's very helpful! Here's a reissue of https://github.com/stanfordnlp/CoreNLP/pull/872 with a new version of our tool. The tool made many fewer transformations. Again, we'd appreciate any feedback and are willing to make further changes if you wish to incorporate our PR into your project.

Settings
---
We have several analysis settings. We can vary these settings and rerun if you desire. The settings we are using in this pull request are:

Treat CONFIG, WARNING, and SEVERE levels as a category and not a traditional level, i.e., our tool ignores these log levels.
Never lower the logging level of logging statements within catch blocks.
Never lower the logging level of logging statements within if statements.
Never lower the logging level of logging statements containing certain (important) keywords.
Never raise the logging level of logging statements without particular keywords in their messages.
Avoid log wrapping by disregarding logging statements contained in if statements mentioning log levels.
The greatest number of commits from HEAD evaluated: 1000.
The head at the time of analysis was: d7356dbfa650cfb5b9d33abb0772bb73b9673226


