### PR TITLE
Rejuvenate log levels (C/1000)

### DIFF
--- a/src/edu/stanford/nlp/ie/machinereading/GenericDataSetReader.java
+++ b/src/edu/stanford/nlp/ie/machinereading/GenericDataSetReader.java
@@ -226,7 +226,7 @@ public class GenericDataSetReader  {
       CoreLabel label = (CoreLabel) sh.label();
       headPos = label.get(CoreAnnotations.BeginIndexAnnotation.class);
     } else {
-      logger.fine("WARNING: failed to find syntactic head for entity: " + ent + " in tree: " + tree);
+      logger.info("WARNING: failed to find syntactic head for entity: " + ent + " in tree: " + tree);
       logger.fine("Fallback strategy: will set head to last token in mention: " + tokens.get(headPos));
     }
     ent.setHeadTokenPosition(headPos);


### PR DESCRIPTION
We appreciate your previous feedback and it's very helpful! Here's a reissue of https://github.com/stanfordnlp/CoreNLP/pull/872 with a new version of our tool. The tool made many fewer transformations. Again, we'd appreciate any feedback and are willing to make further changes if you wish to incorporate our PR into your project.

Settings
---
We have several analysis settings. We can vary these settings and rerun if you desire. The settings we are using in this pull request are:

Treat CONFIG levels as a category and not a traditional level, i.e., our tool ignores these log levels.
Never lower the logging level of logging statements within catch blocks.
Never lower the logging level of logging statements within if statements.
Never lower the logging level of logging statements containing certain (important) keywords.
Never raise the logging level of logging statements without particular keywords in their messages.
Avoid log wrapping by disregarding logging statements contained in if statements mentioning log levels.
The greatest number of commits from HEAD evaluated: 1000.
The head at the time of analysis was: d7356dbfa650cfb5b9d33abb0772bb73b9673226
