### PR TITLE
Rejuvenate log levels (CWS/6000)

### DIFF
--- a/src/edu/stanford/nlp/dcoref/CoNLL2011DocumentReader.java
+++ b/src/edu/stanford/nlp/dcoref/CoNLL2011DocumentReader.java
@@ -121,7 +121,7 @@ public class CoNLL2011DocumentReader  {
         docIterator = new DocumentIterator(curFile.getAbsolutePath(), options);
       }
       while ( ! docIterator.hasNext()) {
-        logger.info("Processed " + docIterator.docCnt + " documents in " + curFile.getAbsolutePath());
+        logger.finest("Processed " + docIterator.docCnt + " documents in " + curFile.getAbsolutePath());
         docIterator.close();
         curFileIndex++;
         if (curFileIndex >= fileList.size()) {
@@ -131,7 +131,7 @@ public class CoNLL2011DocumentReader  {
         docIterator = new DocumentIterator(curFile.getAbsolutePath(), options);
       }
       Document next = docIterator.next();
-      SieveCoreferenceSystem.logger.fine("Reading document: " + next.getDocumentID());
+      SieveCoreferenceSystem.logger.finest("Reading document: " + next.getDocumentID());
       return next;
     } catch (IOException ex) {
       throw new RuntimeIOException(ex);
@@ -971,7 +971,7 @@ public class CoNLL2011DocumentReader  {
       System.exit(-1);
     }
     PrintWriter fout = new PrintWriter(outfile);
-    logger.info("Writing to " + outfile);
+    logger.finest("Writing to " + outfile);
     String ext = props.getProperty("ext");
     Options options;
     if (ext != null) {

--- a/src/edu/stanford/nlp/dcoref/Constants.java
+++ b/src/edu/stanford/nlp/dcoref/Constants.java
@@ -121,35 +121,35 @@ public class Constants {
 
   /** print the values of variables in this class */
   public static void printConstants(Logger logger) {
-    if (Constants.USE_ANIMACY_LIST) logger.info("USE_ANIMACY_LIST on");
-    else logger.info("USE_ANIMACY_LIST off");
-    if (Constants.USE_ANIMACY_LIST) logger.info("USE_ANIMACY_LIST on");
-    else logger.info("USE_ANIMACY_LIST off");
-    if (Constants.USE_DISCOURSE_SALIENCE) logger.info("use discourse salience");
-    else logger.info("not use discourse salience");
-    if (Constants.USE_TRUECASE) logger.info("use truecase annotator");
-    else logger.info("not use truecase annotator");
-    if (Constants.USE_DISCOURSE_CONSTRAINTS) logger.info("USE_DISCOURSE_CONSTRAINTS on");
-    else logger.info("USE_DISCOURSE_CONSTRAINTS off");
-    if (Constants.USE_GOLD_POS) logger.info("USE_GOLD_POS on");
-    else logger.info("USE_GOLD_POS off");
-    if (Constants.USE_GOLD_NE) logger.info("use gold NE type annotation");
-    else logger.info("use Stanford NER");
-    if (Constants.USE_GOLD_PARSES) logger.info("USE_GOLD_PARSES on");
-    else logger.info("USE_GOLD_PARSES off");
-    if (Constants.USE_GOLD_SPEAKER_TAGS) logger.info("USE_GOLD_SPEAKER_TAGS on");
-    else logger.info("USE_GOLD_SPEAKER_TAGS off");
-    if (Constants.USE_GOLD_MENTIONS) logger.info("USE_GOLD_MENTIONS on");
-    else logger.info("USE_GOLD_MENTIONS off");
-    if (Constants.USE_GOLD_MENTION_BOUNDARIES) logger.info("USE_GOLD_MENTION_BOUNDARIES on");
-    else logger.info("USE_GOLD_MENTION_BOUNDARIES off");
-    if (Constants.USE_CONLL_AUTO) logger.info("use conll auto set -> if GOLD_NE, GOLD_PARSE, GOLD_POS, etc turned on, use auto");
-    else logger.info("use conll gold set -> if GOLD_NE, GOLD_PARSE, GOLD_POS, etc turned on, use gold");
-    if (Constants.REMOVE_SINGLETONS) logger.info("REMOVE_SINGLETONS on");
-    else logger.info("REMOVE_SINGLETONS off");
-    if (Constants.REMOVE_APPOSITION_PREDICATENOMINATIVES) logger.info("REMOVE_APPOSITION_PREDICATENOMINATIVES on");
-    else logger.info("REMOVE_APPOSITION_PREDICATENOMINATIVES off");
-    logger.info("=================================================================");
+    if (Constants.USE_ANIMACY_LIST) logger.finer("USE_ANIMACY_LIST on");
+    else logger.finer("USE_ANIMACY_LIST off");
+    if (Constants.USE_ANIMACY_LIST) logger.finer("USE_ANIMACY_LIST on");
+    else logger.finer("USE_ANIMACY_LIST off");
+    if (Constants.USE_DISCOURSE_SALIENCE) logger.finer("use discourse salience");
+    else logger.finer("not use discourse salience");
+    if (Constants.USE_TRUECASE) logger.finer("use truecase annotator");
+    else logger.finer("not use truecase annotator");
+    if (Constants.USE_DISCOURSE_CONSTRAINTS) logger.finer("USE_DISCOURSE_CONSTRAINTS on");
+    else logger.finer("USE_DISCOURSE_CONSTRAINTS off");
+    if (Constants.USE_GOLD_POS) logger.finer("USE_GOLD_POS on");
+    else logger.finer("USE_GOLD_POS off");
+    if (Constants.USE_GOLD_NE) logger.finer("use gold NE type annotation");
+    else logger.finer("use Stanford NER");
+    if (Constants.USE_GOLD_PARSES) logger.finer("USE_GOLD_PARSES on");
+    else logger.finer("USE_GOLD_PARSES off");
+    if (Constants.USE_GOLD_SPEAKER_TAGS) logger.finer("USE_GOLD_SPEAKER_TAGS on");
+    else logger.finer("USE_GOLD_SPEAKER_TAGS off");
+    if (Constants.USE_GOLD_MENTIONS) logger.finer("USE_GOLD_MENTIONS on");
+    else logger.finer("USE_GOLD_MENTIONS off");
+    if (Constants.USE_GOLD_MENTION_BOUNDARIES) logger.finer("USE_GOLD_MENTION_BOUNDARIES on");
+    else logger.finer("USE_GOLD_MENTION_BOUNDARIES off");
+    if (Constants.USE_CONLL_AUTO) logger.finer("use conll auto set -> if GOLD_NE, GOLD_PARSE, GOLD_POS, etc turned on, use auto");
+    else logger.finer("use conll gold set -> if GOLD_NE, GOLD_PARSE, GOLD_POS, etc turned on, use gold");
+    if (Constants.REMOVE_SINGLETONS) logger.finer("REMOVE_SINGLETONS on");
+    else logger.finer("REMOVE_SINGLETONS off");
+    if (Constants.REMOVE_APPOSITION_PREDICATENOMINATIVES) logger.finer("REMOVE_APPOSITION_PREDICATENOMINATIVES on");
+    else logger.finer("REMOVE_APPOSITION_PREDICATENOMINATIVES off");
+    logger.finer("=================================================================");
   }
 
 }

--- a/src/edu/stanford/nlp/dcoref/CorefScorer.java
+++ b/src/edu/stanford/nlp/dcoref/CorefScorer.java
@@ -81,14 +81,14 @@ public abstract class CorefScorer {
     if (printF1First) {
       String str = "F1 = "+F1+", P = "+P+" ("+(int) precisionNumSum+"/"+(int) precisionDenSum+"), R = "+R+" ("+(int) recallNumSum+"/"+(int) recallDenSum+")";
       if(scoreType == ScoreType.Pairwise){
-        logger.fine("Pairwise "+str);
+        logger.finest("Pairwise "+str);
       } else if(scoreType == ScoreType.BCubed){
-        logger.fine("B cubed  "+str);
+        logger.finest("B cubed  "+str);
       } else {
-        logger.fine("MUC      "+str);
+        logger.finest("MUC      "+str);
       }
     } else {
-      logger.fine("& "+PP+" & "+RR + " & "+F1F1);
+      logger.finest("& "+PP+" & "+RR + " & "+F1F1);
     }
   }
 

--- a/src/edu/stanford/nlp/dcoref/MentionExtractor.java
+++ b/src/edu/stanford/nlp/dcoref/MentionExtractor.java
@@ -429,7 +429,7 @@ public class MentionExtractor {
       annoSb.append(", parse");
     }
     String annoStr = annoSb.toString();
-    SieveCoreferenceSystem.logger.info("MentionExtractor ignores specified annotators, using annotators=" + annoStr);
+    SieveCoreferenceSystem.logger.fine("MentionExtractor ignores specified annotators, using annotators=" + annoStr);
     pipelineProps.setProperty("annotators", annoStr);
     return new StanfordCoreNLP(pipelineProps, false);
   }

--- a/src/edu/stanford/nlp/dcoref/SieveCoreferenceSystem.java
+++ b/src/edu/stanford/nlp/dcoref/SieveCoreferenceSystem.java
@@ -423,12 +423,12 @@ public class SieveCoreferenceSystem  {
       conllMentionEvalErrFile = conllOutput +"-"+timeStamp+ ".eval.err.txt";
       conllMentionCorefEvalFile = conllOutput +"-"+timeStamp+ ".coref.eval.txt";
       conllMentionCorefEvalErrFile = conllOutput +"-"+timeStamp+ ".coref.eval.err.txt";
-      logger.info("CONLL MENTION GOLD FILE: " + conllOutputMentionGoldFile);
-      logger.info("CONLL MENTION PREDICTED FILE: " + conllOutputMentionPredictedFile);
-      logger.info("CONLL MENTION EVAL FILE: " + conllMentionEvalFile);
+      logger.finer("CONLL MENTION GOLD FILE: " + conllOutputMentionGoldFile);
+      logger.finer("CONLL MENTION PREDICTED FILE: " + conllOutputMentionPredictedFile);
+      logger.finer("CONLL MENTION EVAL FILE: " + conllMentionEvalFile);
       if (!Constants.SKIP_COREF) {
         logger.info("CONLL MENTION PREDICTED WITH COREF FILE: " + conllOutputMentionCorefPredictedFile);
-        logger.info("CONLL MENTION WITH COREF EVAL FILE: " + conllMentionCorefEvalFile);
+        logger.finer("CONLL MENTION WITH COREF EVAL FILE: " + conllMentionCorefEvalFile);
       }
       writerGold = new PrintWriter(new FileOutputStream(conllOutputMentionGoldFile));
       writerPredicted = new PrintWriter(new FileOutputStream(conllOutputMentionPredictedFile));
@@ -480,11 +480,11 @@ public class SieveCoreferenceSystem  {
         //Identifying possible coreferring mentions in the corpus along with any recall/precision errors with gold corpus
         corefSystem.printTopK(logger, document, corefSystem.semantics);
 
-        logger.fine("pairwise score for this doc: ");
+        logger.finer("pairwise score for this doc: ");
         corefSystem.scoreSingleDoc.get(corefSystem.sieves.length-1).printF1(logger);
-        logger.fine("accumulated score: ");
+        logger.finer("accumulated score: ");
         corefSystem.printF1(true);
-        logger.fine("\n");
+        logger.finer("\n");
       }
       if(Constants.PRINT_CONLL_OUTPUT || corefSystem.replicateCoNLL){
         printConllOutput(document, writerPredictedCoref, false, true);
@@ -502,13 +502,13 @@ public class SieveCoreferenceSystem  {
         //        runConllEval(corefSystem.conllMentionEvalScript, conllOutputMentionGoldFile, conllOutputMentionPredictedFile, conllMentionEvalFile, conllMentionEvalErrFile);
 
         String summary = getConllEvalSummary(corefSystem.conllMentionEvalScript, conllOutputMentionGoldFile, conllOutputMentionPredictedFile);
-        logger.info("\nCONLL EVAL SUMMARY (Before COREF)");
+        logger.finer("\nCONLL EVAL SUMMARY (Before COREF)");
         printScoreSummary(summary, logger, false);
 
         if (!Constants.SKIP_COREF) {
           //          runConllEval(corefSystem.conllMentionEvalScript, conllOutputMentionGoldFile, conllOutputMentionCorefPredictedFile, conllMentionCorefEvalFile, conllMentionCorefEvalErrFile);
           summary = getConllEvalSummary(corefSystem.conllMentionEvalScript, conllOutputMentionGoldFile, conllOutputMentionCorefPredictedFile);
-          logger.info("\nCONLL EVAL SUMMARY (After COREF)");
+          logger.finer("\nCONLL EVAL SUMMARY (After COREF)");
           printScoreSummary(summary, logger, true);
           printFinalConllScore(summary);
           if (corefSystem.optimizeConllScore) {
@@ -561,7 +561,7 @@ public class SieveCoreferenceSystem  {
     String outStr = outSos.toString();
     String errStr = errSos.toString();
     logger.info("Finished distributed coref: " + runDistCmd + ", props=" + propsFile);
-    logger.info("Output: " + outStr);
+    logger.finer("Output: " + outStr);
     if (errStr.length() > 0) {
       logger.info("Error: " + errStr);
     }
@@ -630,7 +630,7 @@ public class SieveCoreferenceSystem  {
   public void optimizeSieveOrdering(MentionExtractor mentionExtractor, Properties props, String timestamp) throws Exception
   {
     logger.info("=============SIEVE OPTIMIZATION START ====================");
-    logger.info("Optimize sieves using score: " + optimizeScoreType);
+    logger.fine("Optimize sieves using score: " + optimizeScoreType);
     FileFilter scoreFilesFilter = new FileFilter() {
       @Override
       public boolean accept(File file) {
@@ -659,7 +659,7 @@ public class SieveCoreferenceSystem  {
         sieves[i] = origSieves[optimizedOrdering.get(i)];
         sieveClassNames[i] = origSieveNames[optimizedOrdering.get(i)];
       }
-      logger.info("*** Optimizing Sieve ordering for pass " + curSievesNumber + " ***");
+      logger.fine("*** Optimizing Sieve ordering for pass " + curSievesNumber + " ***");
       // Get list of sieves that we can pick from for the next sieve
       Set<Integer> selectableSieveIndices = new TreeSet<>(remainingSieveIndices);
       // Based on ordering constraints remove sieves from options
@@ -748,14 +748,14 @@ public class SieveCoreferenceSystem  {
             // try this sieve and see how well it works
             sieves[curSievesNumber] = origSieves[potentialSieveIndex];
             sieveClassNames[curSievesNumber] = origSieveNames[potentialSieveIndex];
-            logger.info("Trying sieve " + curSievesNumber + "="+ sieveClassNames[curSievesNumber] + ": ");
-            logger.info(" Trying sieves: " + StringUtils.join(sieveClassNames,","));
+            logger.fine("Trying sieve " + curSievesNumber + "="+ sieveClassNames[curSievesNumber] + ": ");
+            logger.fine(" Trying sieves: " + StringUtils.join(sieveClassNames,","));
 
             double score = runAndScoreCoref(this, mentionExtractor, props, timestamp);
             // keeps scores so we can select best score and log them
             scores.add(new Pair<>(score, potentialSieveIndex));
-            logger.info(" Trying sieves: " + StringUtils.join(sieveClassNames,","));
-            logger.info(" Trying sieves score: " + score);
+            logger.fine(" Trying sieves: " + StringUtils.join(sieveClassNames,","));
+            logger.fine(" Trying sieves score: " + score);
           }
         }
         // Select bestScore
@@ -769,27 +769,27 @@ public class SieveCoreferenceSystem  {
         // log ordered scores
         Collections.sort(scores);
         Collections.reverse(scores);
-        logger.info("Ordered sieves");
+        logger.fine("Ordered sieves");
         for (Pair<Double,Integer> p:scores) {
-          logger.info("Sieve optimization pass " + curSievesNumber
+          logger.fine("Sieve optimization pass " + curSievesNumber
                   + " scores: Sieve=" + origSieveNames[p.second()] + ", score=" + p.first());
         }
       } else {
         // Only one sieve
-        logger.info("Only one choice for next sieve");
+        logger.fine("Only one choice for next sieve");
         selected = selectableSieveIndices.iterator().next();
       }
       // log sieve we are adding
       sieves[curSievesNumber] = origSieves[selected];
       sieveClassNames[curSievesNumber] = origSieveNames[selected];
-      logger.info("Adding sieve " + curSievesNumber + "="+ sieveClassNames[curSievesNumber] + " to existing sieves: ");
-      logger.info(" Current Sieves: " + StringUtils.join(sieveClassNames,","));
+      logger.fine("Adding sieve " + curSievesNumber + "="+ sieveClassNames[curSievesNumber] + " to existing sieves: ");
+      logger.fine(" Current Sieves: " + StringUtils.join(sieveClassNames,","));
       // select optimal sieve and add it to our optimized ordering
       optimizedOrdering.add(selected);
       remainingSieveIndices.remove(selected);
     }
-    logger.info("Final Sieve Ordering: " + StringUtils.join(sieveClassNames, ","));
-    logger.info("=============SIEVE OPTIMIZATION DONE ====================");
+    logger.fine("Final Sieve Ordering: " + StringUtils.join(sieveClassNames, ","));
+    logger.fine("=============SIEVE OPTIMIZATION DONE ====================");
   }
 
   /**
@@ -1120,15 +1120,15 @@ public class SieveCoreferenceSystem  {
       List<Mention> orderedMentions = orderedMentionsBySentence.get(i);
       for (int j = 0 ; j < orderedMentions.size(); j++) {
         Mention m = orderedMentions.get(j);
-        logger.fine("=========Line: "+i+"\tmention: "+j+"=======================================================");
-        logger.fine(m.spanToString()+"\tmentionID: "+m.mentionID+"\tcorefClusterID: "+m.corefClusterID+"\tgoldCorefClusterID: "+m.goldCorefClusterID);
+        logger.finer("=========Line: "+i+"\tmention: "+j+"=======================================================");
+        logger.finer(m.spanToString()+"\tmentionID: "+m.mentionID+"\tcorefClusterID: "+m.corefClusterID+"\tgoldCorefClusterID: "+m.goldCorefClusterID);
         CorefCluster corefCluster = corefClusters.get(m.corefClusterID);
         if (corefCluster != null) {
           corefCluster.printCorefCluster(logger);
         } else {
           logger.finer("CANNOT find coref cluster for cluster " + m.corefClusterID);
         }
-        logger.fine("-------------------------------------------------------");
+        logger.finer("-------------------------------------------------------");
 
         boolean oneRecallErrorPrinted = false;
         boolean onePrecisionErrorPrinted = false;
@@ -1171,7 +1171,7 @@ public class SieveCoreferenceSystem  {
 
             String chosenness = chosen ? "Chosen" : "Not Chosen";
             String correctness = correct ? "Correct" : "Incorrect";
-            logger.fine("\t" + correctness +"\t\t" + chosenness + "\t"+antecedent.spanToString());
+            logger.finer("\t" + correctness +"\t\t" + chosenness + "\t"+antecedent.spanToString());
             CorefCluster mC = corefClusters.get(m.corefClusterID);
             CorefCluster aC = corefClusters.get(antecedent.corefClusterID);
 
@@ -1203,10 +1203,10 @@ public class SieveCoreferenceSystem  {
             if(chosen) alreadyChoose = true;
           }
         }
-        logger.fine("\n");
+        logger.finer("\n");
       }
     }
-    logger.fine("===============================================================================");
+    logger.finer("===============================================================================");
   }
 
   public void printF1(boolean printF1First) {
@@ -1216,18 +1216,18 @@ public class SieveCoreferenceSystem  {
   }
 
   private void printSieveScore(Document document, DeterministicCorefSieve sieve) {
-    logger.fine("===========================================");
-    logger.fine("pass"+currentSieve+": "+ sieve.flagsToString());
+    logger.finest("===========================================");
+    logger.finest("pass"+currentSieve+": "+ sieve.flagsToString());
     scoreMUC.get(currentSieve).printF1(logger);
     scoreBcubed.get(currentSieve).printF1(logger);
     scorePairwise.get(currentSieve).printF1(logger);
-    logger.fine("# of Clusters: "+document.corefClusters.size() + ",\t# of additional links: "+additionalLinksCount
+    logger.finest("# of Clusters: "+document.corefClusters.size() + ",\t# of additional links: "+additionalLinksCount
         +",\t# of additional correct links: "+additionalCorrectLinksCount
         +",\tprecision of new links: "+1.0*additionalCorrectLinksCount/additionalLinksCount);
-    logger.fine("# of total additional links: "+linksCountInPass.get(currentSieve).second()
+    logger.finest("# of total additional links: "+linksCountInPass.get(currentSieve).second()
         +",\t# of total additional correct links: "+linksCountInPass.get(currentSieve).first()
         +",\taccumulated precision of this pass: "+1.0*linksCountInPass.get(currentSieve).first()/linksCountInPass.get(currentSieve).second());
-    logger.fine("--------------------------------------");
+    logger.finest("--------------------------------------");
   }
   /** Print coref link info */
   private static void printLink(Logger logger, String header, IntTuple src, IntTuple dst, List<List<Mention>> orderedMentionsBySentence) {
@@ -1248,7 +1248,7 @@ public class SieveCoreferenceSystem  {
       sb.append(arg);
       sb.append('\t');
     }
-    logger.fine(sb.toString());
+    logger.finest(sb.toString());
   }
 
   /** print a coref link information including context and parse tree */
@@ -1481,7 +1481,7 @@ public class SieveCoreferenceSystem  {
           sb.append(line).append("\n");
         }
       }
-      logger.info(sb.toString());
+      logger.finest(sb.toString());
     }
   }
   /** Print average F1 of MUC, B^3, CEAF_E */
@@ -1494,7 +1494,7 @@ public class SieveCoreferenceSystem  {
       F1s[i++] = Double.parseDouble(f1Matcher.group(1));
     }
     double finalScore = (F1s[0]+F1s[1]+F1s[3])/3;
-    logger.info("Final conll score ((muc+bcub+ceafe)/3) = " + (new DecimalFormat("#.##")).format(finalScore));
+    logger.finer("Final conll score ((muc+bcub+ceafe)/3) = " + (new DecimalFormat("#.##")).format(finalScore));
   }
 
   private static double getFinalConllScore(String summary, String metricType, String scoreType) {
@@ -1557,7 +1557,7 @@ public class SieveCoreferenceSystem  {
       default:
         throw new IllegalArgumentException("Invalid sub score type:" + subScoreType);
     }
-    logger.info("Final score (" + scoreDesc + ") " + subScoreType + " = " + (new DecimalFormat("#.##")).format(finalScore));
+    logger.fine("Final score (" + scoreDesc + ") " + subScoreType + " = " + (new DecimalFormat("#.##")).format(finalScore));
     return finalScore;
   }
 

--- a/src/edu/stanford/nlp/ie/machinereading/BasicEntityExtractor.java
+++ b/src/edu/stanford/nlp/ie/machinereading/BasicEntityExtractor.java
@@ -174,7 +174,7 @@ public class BasicEntityExtractor implements Extractor  {
       // this is an entity end boundary followed by O
       if (type == null && lastType != null) {
         makeEntityMention(sentence, startIndex, i, lastType, extractedEntities, sentCount);
-        logger.info("Found entity: " + extractedEntities.get(extractedEntities.size() - 1));
+        logger.fine("Found entity: " + extractedEntities.get(extractedEntities.size() - 1));
         startIndex = -1;
       }
 
@@ -189,7 +189,7 @@ public class BasicEntityExtractor implements Extractor  {
           (lastType.startsWith("I-") && type.startsWith("I-") && ! lastType.equals(type)) ||
           (notBIO(lastType) && notBIO(type) && ! lastType.equals(type)))){
         makeEntityMention(sentence, startIndex, i, lastType, extractedEntities, sentCount);
-        logger.info("Found entity: " + extractedEntities.get(extractedEntities.size() - 1));
+        logger.fine("Found entity: " + extractedEntities.get(extractedEntities.size() - 1));
         startIndex = i;
       }
 

--- a/src/edu/stanford/nlp/ie/machinereading/BasicRelationExtractor.java
+++ b/src/edu/stanford/nlp/ie/machinereading/BasicRelationExtractor.java
@@ -245,9 +245,9 @@ public class BasicRelationExtractor implements Extractor {
       predictedLabels.add(label);
 
       if(! testDatum.label().equals(label)){
-        logger.info("Classification: found different type " + label + " for relation: " + testDatum);
+        logger.fine("Classification: found different type " + label + " for relation: " + testDatum);
       } else{
-        logger.info("Classification: found similar type " + label + " for relation: " + testDatum);
+        logger.fine("Classification: found similar type " + label + " for relation: " + testDatum);
       }
     }
 

--- a/src/edu/stanford/nlp/ie/machinereading/GenericDataSetReader.java
+++ b/src/edu/stanford/nlp/ie/machinereading/GenericDataSetReader.java
@@ -227,7 +227,7 @@ public class GenericDataSetReader  {
       headPos = label.get(CoreAnnotations.BeginIndexAnnotation.class);
     } else {
       logger.fine("WARNING: failed to find syntactic head for entity: " + ent + " in tree: " + tree);
-      logger.fine("Fallback strategy: will set head to last token in mention: " + tokens.get(headPos));
+      logger.finest("Fallback strategy: will set head to last token in mention: " + tokens.get(headPos));
     }
     ent.setHeadTokenPosition(headPos);
 
@@ -430,7 +430,7 @@ public class GenericDataSetReader  {
   }
 
   private Tree funkyFindLeafWithApproximateSpan(Tree root, String token, int index, int approximateness) {
-    logger.fine("Looking for " + token + " at pos " + index + " plus upto " + approximateness + " in tree: " + root.pennString());
+    logger.finest("Looking for " + token + " at pos " + index + " plus upto " + approximateness + " in tree: " + root.pennString());
     List<Tree> leaves = root.getLeaves();
     for (Tree leaf : leaves) {
       CoreLabel label = CoreLabel.class.cast(leaf.label());
@@ -460,7 +460,7 @@ public class GenericDataSetReader  {
    *     It will be a leaf in the parse tree.
    */
   public Tree originalFindSyntacticHead(EntityMention ent, Tree root, List<CoreLabel> tokens) {
-    logger.fine("Searching for tree matching " + ent);
+    logger.finer("Searching for tree matching " + ent);
     Tree exactMatch = findTreeWithSpan(root, ent.getExtentTokenStart(), ent.getExtentTokenEnd());
 
     //
@@ -480,7 +480,7 @@ public class GenericDataSetReader  {
       extentTokens.add(tokens.get(i));
 
     Tree tree = parse(extentTokens);
-    logger.fine("No exact match found. Local parse:\n" + tree.pennString());
+    logger.finer("No exact match found. Local parse:\n" + tree.pennString());
     convertToCoreLabels(tree);
     tree.indexSpans(ent.getExtentTokenStart());
     Tree extentHead = safeHead(tree);

--- a/src/edu/stanford/nlp/ie/machinereading/MachineReading.java
+++ b/src/edu/stanford/nlp/ie/machinereading/MachineReading.java
@@ -551,7 +551,7 @@ public class MachineReading  {
       for (RelationMention rm : relationMentions) {
         rm.setSentence(sent);
         if (rm.replaceGoldArgsWithPredicted(entityMentions)) {
-          MachineReadingProperties.logger.info("Successfully mapped all arguments in relation mention: " + rm);
+          MachineReadingProperties.logger.fine("Successfully mapped all arguments in relation mention: " + rm);
           newRels.add(rm);
         } else {
           MachineReadingProperties.logger.info("Dropped relation mention due to failed argument mapping: " + rm);
@@ -580,7 +580,7 @@ public class MachineReading  {
 
       for (ResultsPrinter rp : entityResultsPrinterSet){
         String msg = rp.printResults(testing, predicted);
-        MachineReadingProperties.logger.info("Entity extraction results " + (partition != -1 ? "for partition #" + partition : "") + " using printer " + rp.getClass() + ":\n" + msg);
+        MachineReadingProperties.logger.fine("Entity extraction results " + (partition != -1 ? "for partition #" + partition : "") + " using printer " + rp.getClass() + ":\n" + msg);
       }
       predictions[ENTITY_LEVEL][partitionIndex] = predicted;
     }
@@ -606,7 +606,7 @@ public class MachineReading  {
 
       for (ResultsPrinter rp : getRelationResultsPrinterSet()){
         String msg = rp.printResults(testing, predicted);
-        MachineReadingProperties.logger.info("Relation extraction results " + (partition != -1 ? "for partition #" + partition : "") + " using printer " + rp.getClass() + ":\n" + msg);
+        MachineReadingProperties.logger.fine("Relation extraction results " + (partition != -1 ? "for partition #" + partition : "") + " using printer " + rp.getClass() + ":\n" + msg);
       }
 
       //
@@ -621,11 +621,11 @@ public class MachineReading  {
 
         for (ResultsPrinter rp : entityResultsPrinterSet){
           String msg = rp.printResults(testing, predicted);
-          MachineReadingProperties.logger.info("Entity extraction results AFTER consistency checks " + (partition != -1 ? "for partition #" + partition : "") + " using printer " + rp.getClass() + ":\n" + msg);
+          MachineReadingProperties.logger.fine("Entity extraction results AFTER consistency checks " + (partition != -1 ? "for partition #" + partition : "") + " using printer " + rp.getClass() + ":\n" + msg);
         }
         for (ResultsPrinter rp : getRelationResultsPrinterSet()){
           String msg = rp.printResults(testing, predicted);
-          MachineReadingProperties.logger.info("Relation extraction results AFTER consistency checks " + (partition != -1 ? "for partition #" + partition : "") + " using printer " + rp.getClass() + ":\n" + msg);
+          MachineReadingProperties.logger.fine("Relation extraction results AFTER consistency checks " + (partition != -1 ? "for partition #" + partition : "") + " using printer " + rp.getClass() + ":\n" + msg);
         }
       }
 
@@ -768,7 +768,7 @@ public class MachineReading  {
   }
 
   private static Set<ResultsPrinter> makeResultsPrinters(String classes, String[] args) {
-    MachineReadingProperties.logger.info("Making result printers from " + classes);
+    MachineReadingProperties.logger.fine("Making result printers from " + classes);
     String[] printerClassNames = classes.trim().split(",\\s*");
     HashSet<ResultsPrinter> printers = new HashSet<>();
     for (String printerClassName : printerClassNames) {
@@ -897,22 +897,22 @@ public class MachineReading  {
     // if the serialized file exists, just read it. otherwise read the source
     // and and save the serialized file to disk
     if (MachineReadingProperties.serializeCorpora && serializedSentences.exists() && !forceParseSentences) {
-      MachineReadingProperties.logger.info("Loaded serialized sentences from " + serializedSentences.getAbsolutePath() + "...");
+      MachineReadingProperties.logger.fine("Loaded serialized sentences from " + serializedSentences.getAbsolutePath() + "...");
       corpusSentences = IOUtils.readObjectFromFile(serializedSentences);
-      MachineReadingProperties.logger.info("Done. Loaded " + corpusSentences.get(CoreAnnotations.SentencesAnnotation.class).size() + " sentences.");
+      MachineReadingProperties.logger.fine("Done. Loaded " + corpusSentences.get(CoreAnnotations.SentencesAnnotation.class).size() + " sentences.");
     } else {
       // read the corpus
-      MachineReadingProperties.logger.info("Parsing corpus sentences...");
+      MachineReadingProperties.logger.fine("Parsing corpus sentences...");
       if(MachineReadingProperties.serializeCorpora)
         MachineReadingProperties.logger.info("These sentences will be serialized to " + serializedSentences.getAbsolutePath());
       corpusSentences = reader.parse(sentencesPath);
-      MachineReadingProperties.logger.info("Done. Parsed " + AnnotationUtils.sentenceCount(corpusSentences) + " sentences.");
+      MachineReadingProperties.logger.fine("Done. Parsed " + AnnotationUtils.sentenceCount(corpusSentences) + " sentences.");
 
       // save corpusSentences
       if(MachineReadingProperties.serializeCorpora){
         MachineReadingProperties.logger.info("Serializing parsed sentences to " + serializedSentences.getAbsolutePath() + "...");
         IOUtils.writeObjectToFile(corpusSentences,serializedSentences);
-        MachineReadingProperties.logger.info("Done. Serialized " + AnnotationUtils.sentenceCount(corpusSentences) + " sentences.");
+        MachineReadingProperties.logger.fine("Done. Serialized " + AnnotationUtils.sentenceCount(corpusSentences) + " sentences.");
       }
     }
     return corpusSentences;

--- a/src/edu/stanford/nlp/ie/machinereading/domains/ace/reader/AceDocument.java
+++ b/src/edu/stanford/nlp/ie/machinereading/domains/ace/reader/AceDocument.java
@@ -364,7 +364,7 @@ public class AceDocument extends AceElement  {
    */
   public static AceDocument parseDocument(String prefix, boolean usePredictedBoundaries) throws java.io.IOException,
       org.xml.sax.SAXException, javax.xml.parsers.ParserConfigurationException {
-    mLog.fine("Reading document " + prefix);
+    mLog.finer("Reading document " + prefix);
     AceDocument doc = null;
 
     //
@@ -532,7 +532,7 @@ public class AceDocument extends AceElement  {
   //
   public static AceDocument parseDocument(String prefix, boolean usePredictedBoundaries, String AceVersion) throws java.io.IOException,
       org.xml.sax.SAXException, javax.xml.parsers.ParserConfigurationException {
-    mLog.fine("Reading document " + prefix);
+    mLog.finer("Reading document " + prefix);
     AceDocument doc = null;
 
     //

--- a/src/edu/stanford/nlp/ie/machinereading/structure/EventMention.java
+++ b/src/edu/stanford/nlp/ie/machinereading/structure/EventMention.java
@@ -209,7 +209,7 @@ public class EventMention extends RelationMention  {
       String an = e.getArgNames().get(i);
       // TODO: we might need more complex cycle detection than just contains()...
       if(a instanceof EventMention && ((EventMention) a).contains(this)){
-        logger.info("Found event cycle during merge between e1 " + this + " and e2 " + e);
+        logger.fine("Found event cycle during merge between e1 " + this + " and e2 " + e);
       } else {
         // remove e from a's parents
         if(a instanceof EventMention) ((EventMention) a).removeParent(e);

--- a/src/edu/stanford/nlp/ie/machinereading/structure/RelationMention.java
+++ b/src/edu/stanford/nlp/ie/machinereading/structure/RelationMention.java
@@ -223,7 +223,7 @@ public class RelationMention extends ExtractionObject {
   		}
   		if(newArg != null){
   			newArgs.add(newArg);
-  			logger.info("Replacing relation argument: [" + goldEnt + "] with predicted mention [" + newArg + "]");
+  			logger.finer("Replacing relation argument: [" + goldEnt + "] with predicted mention [" + newArg + "]");
   		} else {
   			/*
   			logger.info("Failed to match relation argument: " + goldEnt);

--- a/src/edu/stanford/nlp/patterns/SPIEDServlet.java
+++ b/src/edu/stanford/nlp/patterns/SPIEDServlet.java
@@ -128,9 +128,9 @@ public class SPIEDServlet extends HttpServlet {
     if(model.equalsIgnoreCase("new"))
       testmode = false;
 
-    logger.info("Testmode is " + testmode);
+    logger.fine("Testmode is " + testmode);
 
-    logger.info("model is " + model);
+    logger.fine("model is " + model);
 
 
     String suggestions;
@@ -152,10 +152,10 @@ public class SPIEDServlet extends HttpServlet {
 
       String modelDir = getServletContext().getRealPath("/WEB-INF/data/"+modelNametoDirName.get(model));
       testProps.setProperty("patternsWordsDir", modelDir);
-      logger.info("Reading saved model from " + modelDir);
+      logger.fine("Reading saved model from " + modelDir);
       String seedWordsFiles="NAME,"+modelDir+"/NAME/seedwords.txt,"+modelDir+"/NAME/phrases.txt";
       String modelPropertiesFile = modelDir+"/model.properties";
-      logger.info("Loading model properties from " + modelPropertiesFile);
+      logger.fine("Loading model properties from " + modelPropertiesFile);
       String stopWordsFile = modelDir+"/stopwords.txt";
       boolean writeOutputFile = false;
       annotate.setUpProperties(jsonObject, false, writeOutputFile, seedWordsFiles);
@@ -175,7 +175,7 @@ public class SPIEDServlet extends HttpServlet {
    * {@inheritDoc}
    */
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-    logger.info("GET SPIED query from " + request.getRemoteAddr());
+    logger.fine("GET SPIED query from " + request.getRemoteAddr());
     if (request.getCharacterEncoding() == null) {
       request.setCharacterEncoding("utf-8");
     }
@@ -203,8 +203,8 @@ public class SPIEDServlet extends HttpServlet {
     StringWriter sw = new StringWriter();
     PrintWriter pw = new PrintWriter(sw);
     t.printStackTrace(pw);
-    logger.info("input is " + input);
-    logger.info(sw.toString());
+    logger.fine("input is " + input);
+    logger.fine(sw.toString());
     out.print("{\"okay\":false, \"reason\":\"Something bad happened. Contact the author.\"}");
   }
 
@@ -212,7 +212,7 @@ public class SPIEDServlet extends HttpServlet {
    * {@inheritDoc}
    */
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-    logger.info("Responding to the request for SPIED");
+    logger.fine("Responding to the request for SPIED");
     getServletContext().log("Responding through SPIED through servlet context!!");
   doGet(request, response);
 //    logger.info("POST SPIED query from " + request.getRemoteAddr());

--- a/src/edu/stanford/nlp/util/logging/JavaUtilLoggingAdaptor.java
+++ b/src/edu/stanford/nlp/util/logging/JavaUtilLoggingAdaptor.java
@@ -104,14 +104,14 @@ public class JavaUtilLoggingAdaptor {
       Logger topLogger = Logger.getLogger(Logger.GLOBAL_LOGGER_NAME);
       topLogger.warning("I'm warning you!");
       topLogger.severe("Now I'm using my severe voice.");
-      topLogger.info("FYI");
+      topLogger.finer("FYI");
 
       Redwood.log(Redwood.DBG, "adapting");
       JavaUtilLoggingAdaptor.adapt();
       topLogger.warning("I'm warning you in Redwood!");
       JavaUtilLoggingAdaptor.adapt(); // should be safe to call this twice
       topLogger.severe("Now I'm using my severe voice in Redwood!");
-      topLogger.info("FYI: Redwood rocks");
+      topLogger.finer("FYI: Redwood rocks");
 
       // make sure original java.util.logging levels are respected
       topLogger.setLevel(Level.OFF);
@@ -125,19 +125,19 @@ public class JavaUtilLoggingAdaptor {
       // topLogger.addHandler(new ConsoleHandler());
       Logger logger = Logger.getLogger(JavaUtilLoggingAdaptor.class.getName());
       topLogger.info("Starting test");
-      logger.log(Level.INFO, "Hello from the class logger");
+      logger.log(Level.FINER, "Hello from the class logger");
 
       Redwood.log("Hello from Redwood!");
       Redwood.rootHandler().addChild(
         RedirectOutputHandler.fromJavaUtilLogging(topLogger));
       Redwood.log("Hello from Redwood -> Java!");
       Redwood.log("Hello from Redwood -> Java again!");
-      logger.log(Level.INFO, "Hello again from the class logger");
+      logger.log(Level.FINER, "Hello again from the class logger");
       Redwood.startTrack("a track");
       Redwood.log("Inside a track");
-      logger.log(Level.INFO, "Hello a third time from the class logger");
+      logger.log(Level.FINER, "Hello a third time from the class logger");
       Redwood.endTrack("a track");
-      logger.log(Level.INFO, "Hello a fourth time from the class logger");
+      logger.log(Level.FINER, "Hello a fourth time from the class logger");
     }
   }
 

--- a/src/edu/stanford/nlp/util/logging/JavaUtilLoggingHandler.java
+++ b/src/edu/stanford/nlp/util/logging/JavaUtilLoggingHandler.java
@@ -30,11 +30,11 @@ public class JavaUtilLoggingHandler extends OutputHandler {
         impl.log(Level.WARNING, line);
         break;
       case DEBUG:
-        impl.log(Level.FINE, line);
+        impl.log(Level.FINER, line);
         break;
       case STDOUT:
       case STDERR:
-        impl.info(line);
+        impl.finer(line);
         break;
       case FORCE:
         throw new IllegalStateException("Should not reach this switch case");


### PR DESCRIPTION
We appreciate your previous feedback and it's very helpful! Here's a reissue of https://github.com/stanfordnlp/CoreNLP/pull/872 with a new version of our tool. The tool made many fewer transformations. Again, we'd appreciate any feedback and are willing to make further changes if you wish to incorporate our PR into your project.

Settings
---
We have several analysis settings. We can vary these settings and rerun if you desire. The settings we are using in this pull request are:

Treat CONFIG, WARNING, and SEVERE levels as a category and not a traditional level, i.e., our tool ignores these log levels.
Never lower the logging level of logging statements within catch blocks.
Never lower the logging level of logging statements within if statements.
Never lower the logging level of logging statements containing certain (important) keywords.
Never raise the logging level of logging statements without particular keywords in their messages.
Avoid log wrapping by disregarding logging statements contained in if statements mentioning log levels.
The greatest number of commits from HEAD evaluated: 6000.
The head at the time of analysis was: d7356dbfa650cfb5b9d33abb0772bb73b9673226

