### PR TITLE
Rejuvenate log levels (C/6000)

### DIFF
--- a/src/edu/stanford/nlp/dcoref/CoNLL2011DocumentReader.java
+++ b/src/edu/stanford/nlp/dcoref/CoNLL2011DocumentReader.java
@@ -121,7 +121,7 @@ public class CoNLL2011DocumentReader  {
         docIterator = new DocumentIterator(curFile.getAbsolutePath(), options);
       }
       while ( ! docIterator.hasNext()) {
-        logger.info("Processed " + docIterator.docCnt + " documents in " + curFile.getAbsolutePath());
+        logger.finest("Processed " + docIterator.docCnt + " documents in " + curFile.getAbsolutePath());
         docIterator.close();
         curFileIndex++;
         if (curFileIndex >= fileList.size()) {
@@ -131,7 +131,7 @@ public class CoNLL2011DocumentReader  {
         docIterator = new DocumentIterator(curFile.getAbsolutePath(), options);
       }
       Document next = docIterator.next();
-      SieveCoreferenceSystem.logger.fine("Reading document: " + next.getDocumentID());
+      SieveCoreferenceSystem.logger.finest("Reading document: " + next.getDocumentID());
       return next;
     } catch (IOException ex) {
       throw new RuntimeIOException(ex);
@@ -971,7 +971,7 @@ public class CoNLL2011DocumentReader  {
       System.exit(-1);
     }
     PrintWriter fout = new PrintWriter(outfile);
-    logger.info("Writing to " + outfile);
+    logger.finest("Writing to " + outfile);
     String ext = props.getProperty("ext");
     Options options;
     if (ext != null) {

--- a/src/edu/stanford/nlp/dcoref/CoNLLMentionExtractor.java
+++ b/src/edu/stanford/nlp/dcoref/CoNLLMentionExtractor.java
@@ -125,7 +125,7 @@ public class CoNLLMentionExtractor extends MentionExtractor {
           sentence.set(SemanticGraphCoreAnnotations.BasicDependenciesAnnotation.class, basicDeps);
           sentence.set(SemanticGraphCoreAnnotations.EnhancedDependenciesAnnotation.class, deps);
         } catch(Exception e) {
-          logger.log(Level.WARNING, "Exception caught during extraction of Stanford dependencies. Will ignore and continue...", e);
+          logger.log(Level.SEVERE, "Exception caught during extraction of Stanford dependencies. Will ignore and continue...", e);
         }
       }
     }

--- a/src/edu/stanford/nlp/dcoref/Constants.java
+++ b/src/edu/stanford/nlp/dcoref/Constants.java
@@ -121,35 +121,35 @@ public class Constants {
 
   /** print the values of variables in this class */
   public static void printConstants(Logger logger) {
-    if (Constants.USE_ANIMACY_LIST) logger.info("USE_ANIMACY_LIST on");
-    else logger.info("USE_ANIMACY_LIST off");
-    if (Constants.USE_ANIMACY_LIST) logger.info("USE_ANIMACY_LIST on");
-    else logger.info("USE_ANIMACY_LIST off");
-    if (Constants.USE_DISCOURSE_SALIENCE) logger.info("use discourse salience");
-    else logger.info("not use discourse salience");
-    if (Constants.USE_TRUECASE) logger.info("use truecase annotator");
-    else logger.info("not use truecase annotator");
-    if (Constants.USE_DISCOURSE_CONSTRAINTS) logger.info("USE_DISCOURSE_CONSTRAINTS on");
-    else logger.info("USE_DISCOURSE_CONSTRAINTS off");
-    if (Constants.USE_GOLD_POS) logger.info("USE_GOLD_POS on");
-    else logger.info("USE_GOLD_POS off");
-    if (Constants.USE_GOLD_NE) logger.info("use gold NE type annotation");
-    else logger.info("use Stanford NER");
-    if (Constants.USE_GOLD_PARSES) logger.info("USE_GOLD_PARSES on");
-    else logger.info("USE_GOLD_PARSES off");
-    if (Constants.USE_GOLD_SPEAKER_TAGS) logger.info("USE_GOLD_SPEAKER_TAGS on");
-    else logger.info("USE_GOLD_SPEAKER_TAGS off");
-    if (Constants.USE_GOLD_MENTIONS) logger.info("USE_GOLD_MENTIONS on");
-    else logger.info("USE_GOLD_MENTIONS off");
-    if (Constants.USE_GOLD_MENTION_BOUNDARIES) logger.info("USE_GOLD_MENTION_BOUNDARIES on");
-    else logger.info("USE_GOLD_MENTION_BOUNDARIES off");
-    if (Constants.USE_CONLL_AUTO) logger.info("use conll auto set -> if GOLD_NE, GOLD_PARSE, GOLD_POS, etc turned on, use auto");
-    else logger.info("use conll gold set -> if GOLD_NE, GOLD_PARSE, GOLD_POS, etc turned on, use gold");
-    if (Constants.REMOVE_SINGLETONS) logger.info("REMOVE_SINGLETONS on");
-    else logger.info("REMOVE_SINGLETONS off");
-    if (Constants.REMOVE_APPOSITION_PREDICATENOMINATIVES) logger.info("REMOVE_APPOSITION_PREDICATENOMINATIVES on");
-    else logger.info("REMOVE_APPOSITION_PREDICATENOMINATIVES off");
-    logger.info("=================================================================");
+    if (Constants.USE_ANIMACY_LIST) logger.fine("USE_ANIMACY_LIST on");
+    else logger.fine("USE_ANIMACY_LIST off");
+    if (Constants.USE_ANIMACY_LIST) logger.fine("USE_ANIMACY_LIST on");
+    else logger.fine("USE_ANIMACY_LIST off");
+    if (Constants.USE_DISCOURSE_SALIENCE) logger.fine("use discourse salience");
+    else logger.fine("not use discourse salience");
+    if (Constants.USE_TRUECASE) logger.fine("use truecase annotator");
+    else logger.fine("not use truecase annotator");
+    if (Constants.USE_DISCOURSE_CONSTRAINTS) logger.fine("USE_DISCOURSE_CONSTRAINTS on");
+    else logger.fine("USE_DISCOURSE_CONSTRAINTS off");
+    if (Constants.USE_GOLD_POS) logger.fine("USE_GOLD_POS on");
+    else logger.fine("USE_GOLD_POS off");
+    if (Constants.USE_GOLD_NE) logger.fine("use gold NE type annotation");
+    else logger.fine("use Stanford NER");
+    if (Constants.USE_GOLD_PARSES) logger.fine("USE_GOLD_PARSES on");
+    else logger.fine("USE_GOLD_PARSES off");
+    if (Constants.USE_GOLD_SPEAKER_TAGS) logger.fine("USE_GOLD_SPEAKER_TAGS on");
+    else logger.fine("USE_GOLD_SPEAKER_TAGS off");
+    if (Constants.USE_GOLD_MENTIONS) logger.fine("USE_GOLD_MENTIONS on");
+    else logger.fine("USE_GOLD_MENTIONS off");
+    if (Constants.USE_GOLD_MENTION_BOUNDARIES) logger.fine("USE_GOLD_MENTION_BOUNDARIES on");
+    else logger.fine("USE_GOLD_MENTION_BOUNDARIES off");
+    if (Constants.USE_CONLL_AUTO) logger.fine("use conll auto set -> if GOLD_NE, GOLD_PARSE, GOLD_POS, etc turned on, use auto");
+    else logger.fine("use conll gold set -> if GOLD_NE, GOLD_PARSE, GOLD_POS, etc turned on, use gold");
+    if (Constants.REMOVE_SINGLETONS) logger.fine("REMOVE_SINGLETONS on");
+    else logger.fine("REMOVE_SINGLETONS off");
+    if (Constants.REMOVE_APPOSITION_PREDICATENOMINATIVES) logger.fine("REMOVE_APPOSITION_PREDICATENOMINATIVES on");
+    else logger.fine("REMOVE_APPOSITION_PREDICATENOMINATIVES off");
+    logger.fine("=================================================================");
   }
 
 }

--- a/src/edu/stanford/nlp/dcoref/CorefScorer.java
+++ b/src/edu/stanford/nlp/dcoref/CorefScorer.java
@@ -81,14 +81,14 @@ public abstract class CorefScorer {
     if (printF1First) {
       String str = "F1 = "+F1+", P = "+P+" ("+(int) precisionNumSum+"/"+(int) precisionDenSum+"), R = "+R+" ("+(int) recallNumSum+"/"+(int) recallDenSum+")";
       if(scoreType == ScoreType.Pairwise){
-        logger.fine("Pairwise "+str);
+        logger.finest("Pairwise "+str);
       } else if(scoreType == ScoreType.BCubed){
-        logger.fine("B cubed  "+str);
+        logger.finest("B cubed  "+str);
       } else {
-        logger.fine("MUC      "+str);
+        logger.finest("MUC      "+str);
       }
     } else {
-      logger.fine("& "+PP+" & "+RR + " & "+F1F1);
+      logger.finest("& "+PP+" & "+RR + " & "+F1F1);
     }
   }
 

--- a/src/edu/stanford/nlp/dcoref/Document.java
+++ b/src/edu/stanford/nlp/dcoref/Document.java
@@ -352,7 +352,7 @@ public class Document implements Serializable {
             }
             existingMentions.append(eg.mentionID);
           }
-          SieveCoreferenceSystem.logger.warning("WARNING: gold mentions with the same offsets: " + ip
+          SieveCoreferenceSystem.logger.fine("WARNING: gold mentions with the same offsets: " + ip
                   + " mentions=" + g.mentionID + "," + existingMentions + ", " + g.spanToString());
         }
         //assert(!goldMentionPositions.containsKey(ip));
@@ -727,7 +727,7 @@ public class Document implements Serializable {
             }
           }
         } else {
-          SieveCoreferenceSystem.logger.warning("Cannot find node in dependency for word " + word);
+          SieveCoreferenceSystem.logger.info("Cannot find node in dependency for word " + word);
         }
       }
     }

--- a/src/edu/stanford/nlp/dcoref/RuleBasedCorefMentionFinder.java
+++ b/src/edu/stanford/nlp/dcoref/RuleBasedCorefMentionFinder.java
@@ -272,7 +272,7 @@ public class RuleBasedCorefMentionFinder implements CorefMentionFinder  {
       if (start < 0 || start >= m.originalSpan.size()) {
         SieveCoreferenceSystem.logger.warning("Invalid index for head " + start + "=" + m.headIndex + "-" + m.startIndex
                 + ": originalSpan=[" + StringUtils.joinWords(m.originalSpan, " ") + "], head=" + m.headWord);
-        SieveCoreferenceSystem.logger.warning("Setting head string to entire mention");
+        SieveCoreferenceSystem.logger.fine("Setting head string to entire mention");
         m.headIndex = m.startIndex;
         m.headWord = m.originalSpan.size() > 0 ? m.originalSpan.get(0) : sent.get(m.startIndex);
         m.headString = m.originalSpan.toString();

--- a/src/edu/stanford/nlp/dcoref/SieveCoreferenceSystem.java
+++ b/src/edu/stanford/nlp/dcoref/SieveCoreferenceSystem.java
@@ -423,12 +423,12 @@ public class SieveCoreferenceSystem  {
       conllMentionEvalErrFile = conllOutput +"-"+timeStamp+ ".eval.err.txt";
       conllMentionCorefEvalFile = conllOutput +"-"+timeStamp+ ".coref.eval.txt";
       conllMentionCorefEvalErrFile = conllOutput +"-"+timeStamp+ ".coref.eval.err.txt";
-      logger.info("CONLL MENTION GOLD FILE: " + conllOutputMentionGoldFile);
-      logger.info("CONLL MENTION PREDICTED FILE: " + conllOutputMentionPredictedFile);
-      logger.info("CONLL MENTION EVAL FILE: " + conllMentionEvalFile);
+      logger.fine("CONLL MENTION GOLD FILE: " + conllOutputMentionGoldFile);
+      logger.fine("CONLL MENTION PREDICTED FILE: " + conllOutputMentionPredictedFile);
+      logger.fine("CONLL MENTION EVAL FILE: " + conllMentionEvalFile);
       if (!Constants.SKIP_COREF) {
         logger.info("CONLL MENTION PREDICTED WITH COREF FILE: " + conllOutputMentionCorefPredictedFile);
-        logger.info("CONLL MENTION WITH COREF EVAL FILE: " + conllMentionCorefEvalFile);
+        logger.fine("CONLL MENTION WITH COREF EVAL FILE: " + conllMentionCorefEvalFile);
       }
       writerGold = new PrintWriter(new FileOutputStream(conllOutputMentionGoldFile));
       writerPredicted = new PrintWriter(new FileOutputStream(conllOutputMentionPredictedFile));
@@ -502,13 +502,13 @@ public class SieveCoreferenceSystem  {
         //        runConllEval(corefSystem.conllMentionEvalScript, conllOutputMentionGoldFile, conllOutputMentionPredictedFile, conllMentionEvalFile, conllMentionEvalErrFile);
 
         String summary = getConllEvalSummary(corefSystem.conllMentionEvalScript, conllOutputMentionGoldFile, conllOutputMentionPredictedFile);
-        logger.info("\nCONLL EVAL SUMMARY (Before COREF)");
+        logger.fine("\nCONLL EVAL SUMMARY (Before COREF)");
         printScoreSummary(summary, logger, false);
 
         if (!Constants.SKIP_COREF) {
           //          runConllEval(corefSystem.conllMentionEvalScript, conllOutputMentionGoldFile, conllOutputMentionCorefPredictedFile, conllMentionCorefEvalFile, conllMentionCorefEvalErrFile);
           summary = getConllEvalSummary(corefSystem.conllMentionEvalScript, conllOutputMentionGoldFile, conllOutputMentionCorefPredictedFile);
-          logger.info("\nCONLL EVAL SUMMARY (After COREF)");
+          logger.fine("\nCONLL EVAL SUMMARY (After COREF)");
           printScoreSummary(summary, logger, true);
           printFinalConllScore(summary);
           if (corefSystem.optimizeConllScore) {
@@ -561,7 +561,7 @@ public class SieveCoreferenceSystem  {
     String outStr = outSos.toString();
     String errStr = errSos.toString();
     logger.info("Finished distributed coref: " + runDistCmd + ", props=" + propsFile);
-    logger.info("Output: " + outStr);
+    logger.fine("Output: " + outStr);
     if (errStr.length() > 0) {
       logger.info("Error: " + errStr);
     }
@@ -1216,18 +1216,18 @@ public class SieveCoreferenceSystem  {
   }
 
   private void printSieveScore(Document document, DeterministicCorefSieve sieve) {
-    logger.fine("===========================================");
-    logger.fine("pass"+currentSieve+": "+ sieve.flagsToString());
+    logger.finest("===========================================");
+    logger.finest("pass"+currentSieve+": "+ sieve.flagsToString());
     scoreMUC.get(currentSieve).printF1(logger);
     scoreBcubed.get(currentSieve).printF1(logger);
     scorePairwise.get(currentSieve).printF1(logger);
-    logger.fine("# of Clusters: "+document.corefClusters.size() + ",\t# of additional links: "+additionalLinksCount
+    logger.finest("# of Clusters: "+document.corefClusters.size() + ",\t# of additional links: "+additionalLinksCount
         +",\t# of additional correct links: "+additionalCorrectLinksCount
         +",\tprecision of new links: "+1.0*additionalCorrectLinksCount/additionalLinksCount);
-    logger.fine("# of total additional links: "+linksCountInPass.get(currentSieve).second()
+    logger.finest("# of total additional links: "+linksCountInPass.get(currentSieve).second()
         +",\t# of total additional correct links: "+linksCountInPass.get(currentSieve).first()
         +",\taccumulated precision of this pass: "+1.0*linksCountInPass.get(currentSieve).first()/linksCountInPass.get(currentSieve).second());
-    logger.fine("--------------------------------------");
+    logger.finest("--------------------------------------");
   }
   /** Print coref link info */
   private static void printLink(Logger logger, String header, IntTuple src, IntTuple dst, List<List<Mention>> orderedMentionsBySentence) {
@@ -1248,7 +1248,7 @@ public class SieveCoreferenceSystem  {
       sb.append(arg);
       sb.append('\t');
     }
-    logger.fine(sb.toString());
+    logger.finest(sb.toString());
   }
 
   /** print a coref link information including context and parse tree */
@@ -1481,7 +1481,7 @@ public class SieveCoreferenceSystem  {
           sb.append(line).append("\n");
         }
       }
-      logger.info(sb.toString());
+      logger.finest(sb.toString());
     }
   }
   /** Print average F1 of MUC, B^3, CEAF_E */
@@ -1494,7 +1494,7 @@ public class SieveCoreferenceSystem  {
       F1s[i++] = Double.parseDouble(f1Matcher.group(1));
     }
     double finalScore = (F1s[0]+F1s[1]+F1s[3])/3;
-    logger.info("Final conll score ((muc+bcub+ceafe)/3) = " + (new DecimalFormat("#.##")).format(finalScore));
+    logger.fine("Final conll score ((muc+bcub+ceafe)/3) = " + (new DecimalFormat("#.##")).format(finalScore));
   }
 
   private static double getFinalConllScore(String summary, String metricType, String scoreType) {

--- a/src/edu/stanford/nlp/ie/machinereading/GenericDataSetReader.java
+++ b/src/edu/stanford/nlp/ie/machinereading/GenericDataSetReader.java
@@ -227,7 +227,7 @@ public class GenericDataSetReader  {
       headPos = label.get(CoreAnnotations.BeginIndexAnnotation.class);
     } else {
       logger.fine("WARNING: failed to find syntactic head for entity: " + ent + " in tree: " + tree);
-      logger.fine("Fallback strategy: will set head to last token in mention: " + tokens.get(headPos));
+      logger.finest("Fallback strategy: will set head to last token in mention: " + tokens.get(headPos));
     }
     ent.setHeadTokenPosition(headPos);
 
@@ -430,7 +430,7 @@ public class GenericDataSetReader  {
   }
 
   private Tree funkyFindLeafWithApproximateSpan(Tree root, String token, int index, int approximateness) {
-    logger.fine("Looking for " + token + " at pos " + index + " plus upto " + approximateness + " in tree: " + root.pennString());
+    logger.finest("Looking for " + token + " at pos " + index + " plus upto " + approximateness + " in tree: " + root.pennString());
     List<Tree> leaves = root.getLeaves();
     for (Tree leaf : leaves) {
       CoreLabel label = CoreLabel.class.cast(leaf.label());
@@ -444,7 +444,7 @@ public class GenericDataSetReader  {
     // but it does happen (VERY RARELY) on some weird web text that includes SGML tags with spaces
     // TODO: does this mean that somehow tokenization is different for the parser? check this by throwing an Exception in KBP
     logger.severe("GenericDataSetReader: WARNING: Failed to find head token");
-    logger.severe("  when looking for " + token + " at pos " + index + " plus upto " + approximateness + " in tree: " + root.pennString());
+    logger.finest("  when looking for " + token + " at pos " + index + " plus upto " + approximateness + " in tree: " + root.pennString());
     return null;
   }
 

--- a/src/edu/stanford/nlp/ie/machinereading/MachineReading.java
+++ b/src/edu/stanford/nlp/ie/machinereading/MachineReading.java
@@ -272,7 +272,7 @@ public class MachineReading  {
         MachineReadingProperties.logger.severe("Reading auxiliary dataset from " + MachineReadingProperties.auxDataPath + "...");
         aux = loadOrMakeSerializedSentences(MachineReadingProperties.auxDataPath, auxReader, new File(
                 MachineReadingProperties.serializedAuxTrainingSentencesPath));
-        MachineReadingProperties.logger.severe("Done reading auxiliary dataset.");
+        MachineReadingProperties.logger.info("Done reading auxiliary dataset.");
       }
     }
 
@@ -355,7 +355,7 @@ public class MachineReading  {
     for (ResultsPrinter rp : printers){
       String msg = rp.printResults(gold, pred);
       retMsg.add(msg);
-      MachineReadingProperties.logger.severe("Overall " + taskName + " results, using printer " + rp.getClass() + ":\n" + msg);
+      MachineReadingProperties.logger.info("Overall " + taskName + " results, using printer " + rp.getClass() + ":\n" + msg);
     }
     return retMsg;
   }

--- a/src/edu/stanford/nlp/ie/machinereading/domains/ace/AceReader.java
+++ b/src/edu/stanford/nlp/ie/machinereading/domains/ace/AceReader.java
@@ -346,7 +346,7 @@ public class AceReader extends GenericDataSetReader  {
       ExtractionObject o = entityMap.get(arg.getId());
       if(o == null){
         logger.severe("READER ERROR: Failed to find event argument with id " + arg.getId());
-        logger.severe("This happens because a few event mentions illegally span multiple sentences. Will ignore this mention.");
+        logger.fine("This happens because a few event mentions illegally span multiple sentences. Will ignore this mention.");
         return null;
       }
       convertedArgs.add(o);
@@ -387,7 +387,7 @@ public class AceReader extends GenericDataSetReader  {
       ExtractionObject o = entityMap.get(arg.getContent().getId());
       if(o == null){
         logger.severe("READER ERROR: Failed to find relation argument with id " + arg.getContent().getId());
-        logger.severe("This happens because a few relation mentions illegally span multiple sentences. Will ignore this mention.");
+        logger.fine("This happens because a few relation mentions illegally span multiple sentences. Will ignore this mention.");
         return null;
       }
       convertedArgs.add(o);
@@ -398,7 +398,7 @@ public class AceReader extends GenericDataSetReader  {
 
     if(argNames.size() != 2 || ! argNames.get(0).equalsIgnoreCase("arg-1") || ! argNames.get(1).equalsIgnoreCase("arg-2")){
       logger.severe("READER ERROR: Invalid succession of arguments in relation mention: " + argNames);
-      logger.severe("ACE relations must have two arguments. Will ignore this mention.");
+      logger.fine("ACE relations must have two arguments. Will ignore this mention.");
       return null;
     }
 
@@ -436,12 +436,12 @@ public class AceReader extends GenericDataSetReader  {
     int extEnd = ext.getTokenEnd() - tokenOffset + 1;
     if (extStart < 0) {
       logger.severe("READER ERROR: Invalid extent start " + extStart + " for entity mention " + entityMention.getId() + " in document " + docId + " in sentence " + sentence);
-      logger.severe("This may happen due to incorrect EOS detection. Adjusting entity extent.");
+      logger.finest("This may happen due to incorrect EOS detection. Adjusting entity extent.");
       extStart = 0;
     }
     if (extEnd > sentence.get(CoreAnnotations.TokensAnnotation.class).size()) {
       logger.severe("READER ERROR: Invalid extent end " + extEnd + " for entity mention " + entityMention.getId() + " in document " + docId + " in sentence " + sentence);
-      logger.severe("This may happen due to incorrect EOS detection. Adjusting entity extent.");
+      logger.finest("This may happen due to incorrect EOS detection. Adjusting entity extent.");
       extEnd = sentence.get(CoreAnnotations.TokensAnnotation.class).size();
     }
 
@@ -449,12 +449,12 @@ public class AceReader extends GenericDataSetReader  {
     int headEnd = head.getTokenEnd() - tokenOffset + 1;
     if (headStart < 0) {
       logger.severe("READER ERROR: Invalid head start " + headStart + " for entity mention " + entityMention.getId() + " in document " + docId + " in sentence " + sentence);
-      logger.severe("This may happen due to incorrect EOS detection. Adjusting entity head span.");
+      logger.finest("This may happen due to incorrect EOS detection. Adjusting entity head span.");
       headStart = 0;
     }
     if(headEnd > sentence.get(CoreAnnotations.TokensAnnotation.class).size()){
       logger.severe("READER ERROR: Invalid head end " + headEnd + " for entity mention " + entityMention.getId() + " in document " + docId + " in sentence " + sentence);
-      logger.severe("This may happen due to incorrect EOS detection. Adjusting entity head span.");
+      logger.finest("This may happen due to incorrect EOS detection. Adjusting entity head span.");
       headEnd = sentence.get(CoreAnnotations.TokensAnnotation.class).size();
     }
 

--- a/src/edu/stanford/nlp/ie/machinereading/domains/ace/reader/AceDocument.java
+++ b/src/edu/stanford/nlp/ie/machinereading/domains/ace/reader/AceDocument.java
@@ -393,7 +393,7 @@ public class AceDocument extends AceElement  {
     //
     String trueCasedFileName = prefix + ORIG_EXT + ".truecase";
     if((new File(trueCasedFileName).exists())){
-    	mLog.severe("Using truecased file: " + trueCasedFileName);
+    	mLog.fine("Using truecased file: " + trueCasedFileName);
     	doc.readRawBytes(trueCasedFileName);
     } else {
     	doc.readRawBytes(prefix + ORIG_EXT);
@@ -561,7 +561,7 @@ public class AceDocument extends AceElement  {
     //
     String trueCasedFileName = prefix + ORIG_EXT + ".truecase";
     if((new File(trueCasedFileName).exists())){
-    	mLog.severe("Using truecased file: " + trueCasedFileName);
+    	mLog.fine("Using truecased file: " + trueCasedFileName);
     	doc.readRawBytes(trueCasedFileName);
     } else {
     	doc.readRawBytes(prefix + ORIG_EXT);

--- a/src/edu/stanford/nlp/ie/machinereading/structure/RelationMention.java
+++ b/src/edu/stanford/nlp/ie/machinereading/structure/RelationMention.java
@@ -223,7 +223,7 @@ public class RelationMention extends ExtractionObject {
   		}
   		if(newArg != null){
   			newArgs.add(newArg);
-  			logger.info("Replacing relation argument: [" + goldEnt + "] with predicted mention [" + newArg + "]");
+  			logger.fine("Replacing relation argument: [" + goldEnt + "] with predicted mention [" + newArg + "]");
   		} else {
   			/*
   			logger.info("Failed to match relation argument: " + goldEnt);

--- a/src/edu/stanford/nlp/util/logging/JavaUtilLoggingAdaptor.java
+++ b/src/edu/stanford/nlp/util/logging/JavaUtilLoggingAdaptor.java
@@ -102,16 +102,16 @@ public class JavaUtilLoggingAdaptor {
       Redwood.startTrack("Adaptor test controlled by redwood");
 
       Logger topLogger = Logger.getLogger(Logger.GLOBAL_LOGGER_NAME);
-      topLogger.warning("I'm warning you!");
-      topLogger.severe("Now I'm using my severe voice.");
-      topLogger.info("FYI");
+      topLogger.fine("I'm warning you!");
+      topLogger.fine("Now I'm using my severe voice.");
+      topLogger.fine("FYI");
 
       Redwood.log(Redwood.DBG, "adapting");
       JavaUtilLoggingAdaptor.adapt();
-      topLogger.warning("I'm warning you in Redwood!");
+      topLogger.fine("I'm warning you in Redwood!");
       JavaUtilLoggingAdaptor.adapt(); // should be safe to call this twice
-      topLogger.severe("Now I'm using my severe voice in Redwood!");
-      topLogger.info("FYI: Redwood rocks");
+      topLogger.fine("Now I'm using my severe voice in Redwood!");
+      topLogger.fine("FYI: Redwood rocks");
 
       // make sure original java.util.logging levels are respected
       topLogger.setLevel(Level.OFF);
@@ -125,19 +125,19 @@ public class JavaUtilLoggingAdaptor {
       // topLogger.addHandler(new ConsoleHandler());
       Logger logger = Logger.getLogger(JavaUtilLoggingAdaptor.class.getName());
       topLogger.info("Starting test");
-      logger.log(Level.INFO, "Hello from the class logger");
+      logger.log(Level.FINE, "Hello from the class logger");
 
       Redwood.log("Hello from Redwood!");
       Redwood.rootHandler().addChild(
         RedirectOutputHandler.fromJavaUtilLogging(topLogger));
       Redwood.log("Hello from Redwood -> Java!");
       Redwood.log("Hello from Redwood -> Java again!");
-      logger.log(Level.INFO, "Hello again from the class logger");
+      logger.log(Level.FINE, "Hello again from the class logger");
       Redwood.startTrack("a track");
       Redwood.log("Inside a track");
-      logger.log(Level.INFO, "Hello a third time from the class logger");
+      logger.log(Level.FINE, "Hello a third time from the class logger");
       Redwood.endTrack("a track");
-      logger.log(Level.INFO, "Hello a fourth time from the class logger");
+      logger.log(Level.FINE, "Hello a fourth time from the class logger");
     }
   }
 

--- a/src/edu/stanford/nlp/util/logging/JavaUtilLoggingHandler.java
+++ b/src/edu/stanford/nlp/util/logging/JavaUtilLoggingHandler.java
@@ -24,17 +24,17 @@ public class JavaUtilLoggingHandler extends OutputHandler {
     // Route the signal
     switch (pair.second()) {
       case ERROR:
-        impl.log(Level.SEVERE, line);
+        impl.log(Level.FINE, line);
         break;
       case WARN:
-        impl.log(Level.WARNING, line);
+        impl.log(Level.FINE, line);
         break;
       case DEBUG:
         impl.log(Level.FINE, line);
         break;
       case STDOUT:
       case STDERR:
-        impl.info(line);
+        impl.fine(line);
         break;
       case FORCE:
         throw new IllegalStateException("Should not reach this switch case");


### PR DESCRIPTION
We appreciate your previous feedback and it's very helpful! Here's a reissue of https://github.com/stanfordnlp/CoreNLP/pull/872 with a new version of our tool. The tool made many fewer transformations. Again, we'd appreciate any feedback and are willing to make further changes if you wish to incorporate our PR into your project.

Settings
---
We have several analysis settings. We can vary these settings and rerun if you desire. The settings we are using in this pull request are:

Treat CONFIG levels as a category and not a traditional level, i.e., our tool ignores these log levels.
Never lower the logging level of logging statements within catch blocks.
Never lower the logging level of logging statements within if statements.
Never lower the logging level of logging statements containing certain (important) keywords.
Never raise the logging level of logging statements without particular keywords in their messages.
Avoid log wrapping by disregarding logging statements contained in if statements mentioning log levels.
The greatest number of commits from HEAD evaluated: 6000.
The head at the time of analysis was: d7356dbfa650cfb5b9d33abb0772bb73b9673226
